### PR TITLE
Build picsim on macOS and Linux using github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build picsim
+on: [push]
+jobs:
+  build-macos:
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: make


### PR DESCRIPTION
This adds a Github Action running make on both linux and macOS. 
Github Actions are [free](https://docs.github.com/en/enterprise-cloud@latest/billing/managing-billing-for-github-actions/about-billing-for-github-actions) for public repositories.

Actions are set up to run on every push.

This is to help the maintainer [verify that it builds on macOS](https://github.com/lcgamboa/picsim/pull/3#issuecomment-1094104037)

Example of action running on [my fork](https://github.com/hsorbo/picsim/actions/runs/2141563514)